### PR TITLE
Warn user if`.comet.yaml` is found instead of `.comet.yml`

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -97,9 +97,8 @@ get_config_from_configfile <- function(name, dir) {
   tryCatch({
     file <- file.path(dir, get_config_filename())
     # Check for config file with .yaml instead of .yml
-    filename_yaml = stringr:::str_replace(get_config_filename(), '.yml$', '.yaml')
+    filename_yaml = paste0(strsplit(get_config_filename(), '.yml$')[[1]][1], '.yaml')
     file_yaml = file.path(dir, filename_yaml)
-
     if (file.exists(file)) {
       configs <- suppressWarnings(yaml::read_yaml(file, eval.expr = TRUE))
       configs[[name]]
@@ -116,7 +115,6 @@ get_config_from_configfile <- function(name, dir) {
     }
   }, error = function(err) {
     warning("Error trying to read from config file: ", err$message)
-
     NULL
   })
 }

--- a/R/config.R
+++ b/R/config.R
@@ -97,8 +97,8 @@ get_config_from_configfile <- function(name, dir) {
   tryCatch({
     file <- file.path(dir, get_config_filename())
     # Check for config file with .yaml instead of .yml
-    filename_yaml = paste0(strsplit(get_config_filename(), '.yml$')[[1]][1], '.yaml')
-    file_yaml = file.path(dir, filename_yaml)
+    filename_yaml <- paste0(strsplit(get_config_filename(), '.yml$')[[1]][1], '.yaml')
+    file_yaml <- file.path(dir, filename_yaml)
     if (file.exists(file)) {
       configs <- suppressWarnings(yaml::read_yaml(file, eval.expr = TRUE))
       configs[[name]]

--- a/R/config.R
+++ b/R/config.R
@@ -96,14 +96,27 @@ get_config_from_homedir <- function(name) {
 get_config_from_configfile <- function(name, dir) {
   tryCatch({
     file <- file.path(dir, get_config_filename())
+    # Check for config file with .yaml instead of .yml
+    filename_yaml = stringr:::str_replace(get_config_filename(), '.yml$', '.yaml')
+    file_yaml = file.path(dir, filename_yaml)
+
     if (file.exists(file)) {
       configs <- suppressWarnings(yaml::read_yaml(file, eval.expr = TRUE))
       configs[[name]]
+    } else if (file.exists(file_yaml)){
+      warning("While looking for config file at path: ",
+              file,
+              "\n  Found file with .yaml extension: ",
+              file_yaml,
+              "\n  cometr requires a .yml extension for configuration files.",
+              "\n  Please change the file extension to .yml.")
+      NULL
     } else {
       NULL
     }
   }, error = function(err) {
     warning("Error trying to read from config file: ", err$message)
+
     NULL
   })
 }


### PR DESCRIPTION
This is really just a toy PR as I kick the tires on this library. While getting started with `cometr`, I accidentally named my configuration file `comet.yaml` instead of `.comet.yml`. I got a non-informative error and it took me a minute to realize my mistake. Strictly speaking, `.yaml` is the  ["officially preferred"](https://yaml.org/faq.html) extension, though I'm not so pedantic as to suggest changing it when `.yml` is arguably more common! But I thought I could add an informative warning message.

I also considered modifying the code to allow for `.yaml` or `.yml`. But that gain in flexibility is a detriment if someone ends up with both `comet.yml` and `comet.yaml` in a particular directory. 

Ultimately, I think a better idea would be to add something analagous to `comet_ml.init()`. 